### PR TITLE
fix: 点击白球拖到球桌外松开时也能击打 (fix #3)

### DIFF
--- a/script.js
+++ b/script.js
@@ -204,7 +204,9 @@ function createBalls() {
 function setupEventListeners() {
     canvas.addEventListener('mousedown', handleMouseDown);
     canvas.addEventListener('mousemove', handleMouseMove);
-    canvas.addEventListener('mouseup', handleMouseUp);
+    // 在 document 上监听 mouseup/mousemove，这样拖到球桌外松开也能触发击打
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
     resetButton.addEventListener('click', resetGame);
 }
 


### PR DESCRIPTION
## 修复内容
- 在 \document\ 上监听 \mouseup\，在页面任意位置松开鼠标都会触发击打
- 在 \document\ 上监听 \mousemove\，拖到球桌外时仍更新瞄准方向，击打方向更准确

Closes #3

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to input event listener wiring and should only affect how aiming/shooting is captured when the cursor leaves the canvas.
> 
> **Overview**
> Fixes cue-shot input handling so releasing the mouse outside the billiards table still triggers the shot.
> 
> `setupEventListeners` now listens for `mousemove`/`mouseup` on `document` (instead of only on the `canvas`), keeping aim direction updates and ensuring `handleMouseUp` fires even when the drag exits the table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9d71f6612f0dda9229c38cdc472cc238d273a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->