### PR TITLE
fix: 袋口位置移到台案边缘以外 (fix #5)

### DIFF
--- a/script.js
+++ b/script.js
@@ -118,15 +118,15 @@ function init() {
     setupCollisionEvents();
 }
 
-// Create table pockets
+// Create table pockets (at table edge / outside playing surface, like real table)
 function createPockets() {
     const pocketPositions = [
-        { x: 20, y: 20 },                        // Top-left
-        { x: TABLE_WIDTH / 2, y: 15 },           // Top-middle
-        { x: TABLE_WIDTH - 20, y: 20 },          // Top-right
-        { x: 20, y: TABLE_HEIGHT - 20 },         // Bottom-left
-        { x: TABLE_WIDTH / 2, y: TABLE_HEIGHT - 15 }, // Bottom-middle
-        { x: TABLE_WIDTH - 20, y: TABLE_HEIGHT - 20 } // Bottom-right
+        { x: 0, y: 0 },                          // Top-left corner
+        { x: TABLE_WIDTH / 2, y: 0 },            // Top-middle
+        { x: TABLE_WIDTH, y: 0 },                // Top-right corner
+        { x: 0, y: TABLE_HEIGHT },               // Bottom-left corner
+        { x: TABLE_WIDTH / 2, y: TABLE_HEIGHT }, // Bottom-middle
+        { x: TABLE_WIDTH, y: TABLE_HEIGHT }      // Bottom-right corner
     ];
 
     pocketPositions.forEach(pos => {


### PR DESCRIPTION
## 修复内容
- 将六个袋口中心由台面内侧移至台案边缘/以外（四角与两中袋）
- 与实际台球桌一致：袋口在案边以外，不在案面上

Closes #5

Made with [Cursor](https://cursor.com)