### PR TITLE
fix: 球案木质花纹与台面布料质地 (fix #9)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,10 @@
             <div class="player">Player 2: <span id="player2-score">0</span></div>
             <button id="reset-game">Reset Game</button>
         </div>
-        <div class="table-container">
-            <canvas id="billiards-table"></canvas>
+        <div class="table-wrapper">
+            <div class="table-container">
+                <canvas id="billiards-table"></canvas>
+            </div>
         </div>
     </div>
     

--- a/script.js
+++ b/script.js
@@ -63,7 +63,7 @@ function init() {
     });
     engine.world.gravity.y = 0;
 
-    // Create renderer
+    // Create renderer（台面用布料质地，由 beforeRender 绘制）
     render = Render.create({
         canvas: canvas,
         engine: engine,
@@ -71,9 +71,15 @@ function init() {
             width: TABLE_WIDTH,
             height: TABLE_HEIGHT,
             wireframes: false,
-            background: '#0a4d1c'
+            background: 'transparent',
+            clear: false
         }
     });
+    // 台面布料纹理：每帧在 beforeRender 中绘制
+    setupClothTexture();
+
+    // 在创建墙体前先注册台面布料绘制（beforeRender 里会清空并画布纹）
+    Events.on(render, 'beforeRender', drawClothBackground);
 
     // Create table boundaries (cushions)
     const wallOptions = {
@@ -265,6 +271,51 @@ function setupCustomBallRendering() {
             context.restore();
         });
     });
+}
+
+// 台面布料质地：生成绿呢纹样并在每帧 beforeRender 中绘制
+let clothPattern = null;
+
+function setupClothTexture() {
+    const size = 32;
+    const c = document.createElement('canvas');
+    c.width = size;
+    c.height = size;
+    const ctx = c.getContext('2d');
+    const baseGreen = '#0a4d1c';
+    ctx.fillStyle = baseGreen;
+    ctx.fillRect(0, 0, size, size);
+    // 细密织纹：交叉浅色线
+    ctx.strokeStyle = 'rgba(255,255,255,0.04)';
+    ctx.lineWidth = 1;
+    for (let i = 0; i <= size; i += 4) {
+        ctx.beginPath();
+        ctx.moveTo(i, 0);
+        ctx.lineTo(i, size);
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(0, i);
+        ctx.lineTo(size, i);
+        ctx.stroke();
+    }
+    // 轻微深浅变化模拟布料质感
+    ctx.fillStyle = 'rgba(0,0,0,0.03)';
+    for (let y = 0; y < size; y += 8) {
+        for (let x = (y / 8) % 2 ? 0 : 4; x < size; x += 8) {
+            ctx.fillRect(x, y, 4, 4);
+        }
+    }
+    clothPattern = ctx.createPattern(c, 'repeat');
+}
+
+function drawClothBackground() {
+    const ctx = render.context;
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, TABLE_WIDTH, TABLE_HEIGHT);
+    ctx.fillStyle = clothPattern || '#0a4d1c';
+    ctx.fillRect(0, 0, TABLE_WIDTH, TABLE_HEIGHT);
+    ctx.restore();
 }
 
 // 台面内边界（库边内侧）：球心不得超出此范围，否则会被拉回并反弹

--- a/style.css
+++ b/style.css
@@ -47,11 +47,26 @@ body {
     background-color: #45a049;
 }
 
-.table-container {
-    background-color: #0a4d1c;
-    border: 20px solid #854911;
+/* 球案外框：木质花纹 */
+.table-wrapper {
+    padding: 20px;
     border-radius: 12px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    /* 木质基色 + 木纹线条 */
+    background-color: #6b4423;
+    background-image:
+        linear-gradient(105deg, transparent 40%, rgba(0,0,0,0.08) 40.5%, transparent 41%),
+        linear-gradient(75deg, transparent 45%, rgba(0,0,0,0.06) 45.3%, transparent 45.6%),
+        linear-gradient(95deg, transparent 50%, rgba(0,0,0,0.1) 50.5%, transparent 51%),
+        linear-gradient(90deg, rgba(0,0,0,0.03) 0%, transparent 2%, transparent 98%, rgba(0,0,0,0.04) 100%),
+        linear-gradient(0deg, rgba(0,0,0,0.03) 0%, transparent 2%, transparent 98%, rgba(0,0,0,0.04) 100%);
+    background-size: 120px 80px, 100px 140px, 140px 90px, 100% 100%, 100% 100%;
+    background-position: 0 0, 20px 0, 40px 20px, 0 0, 0 0;
+}
+
+.table-container {
+    background-color: #0a4d1c;
+    border-radius: 4px;
 }
 
 #billiards-table {


### PR DESCRIPTION
## 修复内容
- 球案边框增加木质花纹（CSS 渐变模拟木纹）
- 台面使用布料质地（canvas 绿呢织纹）

Closes #9

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Matter.js render lifecycle by disabling default background clearing and drawing a custom per-frame canvas pattern, which could introduce rendering artifacts or performance regressions. Changes are otherwise isolated to presentation (HTML/CSS) and do not affect gameplay rules.
> 
> **Overview**
> Improves the billiards table presentation by adding a wood-grain outer frame (`.table-wrapper`) around the canvas and updating layout to wrap the existing `.table-container`.
> 
> Switches the Matter.js renderer to a transparent background with manual clearing, then draws a repeating felt-like cloth pattern each frame via a new `beforeRender` hook (`setupClothTexture`/`drawClothBackground`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6dd3511023956d2f6c88cb8981bc07def7aacba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->